### PR TITLE
Security hardening: trusted JWT domain, server-only CDP key note

### DIFF
--- a/extension/packages/nextjs/.env.example.args.mjs
+++ b/extension/packages/nextjs/.env.example.args.mjs
@@ -56,7 +56,9 @@ NEXT_PUBLIC_WEBHOOK_URL=
 
 # ViniApp Backend (required for notifications and analytics)
 VINIAPP_BACKEND=
-# CDP_PROXY_KEY - set in Vercel env vars (do not commit real values)
+# CDP_PROXY_KEY - SERVER-ONLY secret. Set in Vercel env vars (do not commit real
+# values). Never prefix with NEXT_PUBLIC_ and never read it in client components;
+# it must only be used from API routes / server code.
 
 # Cross-platform payment token addresses. Fill only when the app uses payments.
 NEXT_PUBLIC_CELO_USDC_ADDRESS=

--- a/extension/packages/nextjs/app/api/track/open/route.ts
+++ b/extension/packages/nextjs/app/api/track/open/route.ts
@@ -1,5 +1,28 @@
 import { NextRequest, NextResponse } from "next/server";
 
+/**
+ * Resolve the app's own domain from TRUSTED configuration for Farcaster JWT
+ * verification. Never derive it from the request Host header, which an attacker
+ * can forge to verify a token issued for a different domain.
+ */
+function trustedDomain(backendUrl: string): string {
+  const explicit = process.env.NEXT_PUBLIC_URL?.trim();
+  if (explicit) {
+    try {
+      return new URL(explicit).hostname;
+    } catch {
+      /* fall through */
+    }
+  }
+
+  const vercelUrl = process.env.VERCEL_URL?.trim();
+  if (vercelUrl) {
+    return vercelUrl.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+  }
+
+  return new URL(backendUrl).hostname;
+}
+
 export async function POST(request: NextRequest) {
   const cdpKey = process.env.CDP_PROXY_KEY;
   const backendUrl = process.env.VINIAPP_BACKEND;
@@ -20,7 +43,7 @@ export async function POST(request: NextRequest) {
       try {
         const { createClient } = await import("@farcaster/quick-auth");
         const client = createClient();
-        const domain = request.headers.get("host") || new URL(backendUrl).hostname;
+        const domain = trustedDomain(backendUrl);
 
         const payload = await client.verifyJwt({ token: fc_token, domain });
         fcVerified = true;


### PR DESCRIPTION
# Security hardening: trusted JWT domain, server-only CDP key note

Extension half of a platform-wide security review (companions:
`viniapp_backend#31`, `viniapp_frontend#111`). These changes propagate to
**every generated miniapp**.

## What's in here
- `app/api/track/open`: verify the Farcaster Quick Auth JWT against a TRUSTED
  domain resolved from `NEXT_PUBLIC_URL` / `VERCEL_URL`, not the
  attacker-controllable request `Host` header (host-header injection could let a
  forged token verify against a different domain).
- `.env.example`: explicitly mark `CDP_PROXY_KEY` as a server-only secret that
  must never be `NEXT_PUBLIC_` or read client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
